### PR TITLE
Add pencil notes support

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
     .cell[data-c="6"]      { border-left: 2.5px solid var(--border-block);}
     .cell[data-r="3"],
     .cell[data-r="6"]      { border-top: 2.5px solid var(--border-block);}
-    .cell[readonly] {
+    .cell[data-readonly="true"] {
       background: var(--cell-readonly-bg);
       color: var(--text-secondary);
       font-weight: bold;
@@ -158,6 +158,33 @@
     .undo-btn:active { background: var(--accent-hover); }
     .btn:active { background: var(--btn-block-hover); color: var(--accent-hover);}
     .btn:disabled, .undo-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+    .btn.toggled {
+      background: var(--accent);
+      color: #fff;
+      border-color: var(--accent-hover);
+    }
+    .cell-input {
+      width: 100%;
+      height: 100%;
+      border: none;
+      background: transparent;
+      font-size: inherit;
+      text-align: center;
+      color: inherit;
+      font-family: inherit;
+      outline: none;
+    }
+    .notes {
+      position: absolute;
+      top: 2px;
+      left: 2px;
+      font-size: 0.6rem;
+      line-height: 1;
+      color: var(--text-secondary);
+      pointer-events: none;
+      white-space: pre-wrap;
+      z-index: 1;
+    }
     select {
       padding: 0.45rem 0.8rem;
       border-radius: 8px;
@@ -205,6 +232,7 @@
       <button class="btn" id="solveBtn">Lösning</button>
       <button class="btn" id="resetBtn">Återställ</button>
       <button class="btn" id="helperBtn">Lär dig</button>
+      <button class="btn" id="notesBtn">Anteckningar</button>
       <button class="btn" id="themeToggle">Dark Mode</button>
     </div>
     <div id="timer">Tid: 00:00</div>
@@ -235,12 +263,15 @@
     let helperVisible = false;
     let selectedR = null, selectedC = null;
     let moves = [];
+    let notes = [];
+    let notesMode = false;
     const gridEl = document.getElementById('sudoku-grid');
     const msgEl = document.getElementById('msg');
     const helperEl = document.getElementById('helper-panel');
     const timerEl = document.getElementById('timer');
     const undoBtn = document.getElementById('undoBtn');
     const numberPad = document.getElementById('number-pad');
+    const notesBtn = document.getElementById('notesBtn');
     // --- Timer ---
     function startTimer() {
       clearInterval(timerInterval);
@@ -318,18 +349,37 @@
       }
       return puz;
     }
+
+    function createEmptyNotes() {
+      notes = Array(9)
+        .fill()
+        .map(() => Array(9).fill().map(() => []));
+    }
     // --- Render ---
     function render() {
       gridEl.innerHTML='';
       for (let r=0;r<9;r++) for (let c=0;c<9;c++) {
+        const cell = document.createElement('div');
+        cell.className='cell';
+        cell.dataset.r = r;
+        cell.dataset.c = c;
+        if (readonly[r][c]) cell.dataset.readonly = 'true';
+
         const inp = document.createElement('input');
         inp.type='text'; inp.maxLength=1;
-        inp.className='cell'; inp.dataset.r=r; inp.dataset.c=c;
+        inp.className='cell-input';
         if (readonly[r][c]) { inp.value=current[r][c]; inp.readOnly=true; }
         else { inp.value=current[r][c]||''; }
-        inp.onfocus = () => { highlightRC(r,c, inp); };
+        inp.onfocus = () => { highlightRC(r,c, cell); };
         inp.oninput = e => handleInput(e, r, c);
-        gridEl.appendChild(inp);
+        cell.appendChild(inp);
+
+        const notesEl = document.createElement('div');
+        notesEl.className='notes';
+        notesEl.textContent = notes[r][c].sort().join(' ');
+        cell.appendChild(notesEl);
+
+        gridEl.appendChild(cell);
       }
       updateErrors();
       highlightNumberPad();
@@ -346,9 +396,18 @@
       highlightNumberPad();
     }
     function handleInput(e,r,c) {
+      if(notesMode) { e.target.value=current[r][c]||''; return; }
       const v=e.target.value.replace(/[^1-9]/g,'');
-      if (v) { saveMove(r,c,current[r][c]); current[r][c]=+v; e.target.value=v; }
-      else { saveMove(r,c,current[r][c]); current[r][c]=0; e.target.value=''; }
+      if (v) {
+        saveMove(r,c,current[r][c]);
+        current[r][c]=+v;
+        notes[r][c]=[];
+        e.target.value=v;
+      } else {
+        saveMove(r,c,current[r][c]);
+        current[r][c]=0;
+        e.target.value='';
+      }
       updateErrors();
       highlightNumberPad();
     }
@@ -379,9 +438,17 @@
         btn.onclick = () => {
           if(selectedR==null||selectedC==null) return;
           if(readonly[selectedR][selectedC]) return;
-          saveMove(selectedR,selectedC,current[selectedR][selectedC]);
-          current[selectedR][selectedC]=i;
-          render();
+          if(notesMode) {
+            const arr = notes[selectedR][selectedC];
+            const idx = arr.indexOf(i);
+            if(idx>-1) arr.splice(idx,1); else arr.push(i);
+            render();
+          } else {
+            saveMove(selectedR,selectedC,current[selectedR][selectedC]);
+            current[selectedR][selectedC]=i;
+            notes[selectedR][selectedC]=[];
+            render();
+          }
         };
         numberPad.appendChild(btn);
       }
@@ -389,6 +456,7 @@
     function highlightNumberPad() {
       // Markera aktiv cell på pad
       document.querySelectorAll('.number-btn').forEach(btn => btn.classList.remove('selected'));
+      if(notesMode) return;
       if(selectedR!=null && selectedC!=null) {
         let v = current[selectedR][selectedC];
         if(v) document.querySelector('.number-btn:nth-child(' + v + ')')?.classList.add('selected');
@@ -419,6 +487,8 @@
       msgEl.textContent=''; helperEl.classList.add('hidden'); helperVisible=false;
       moves = [];
       selectedR = selectedC = null;
+      createEmptyNotes();
+      notesMode = false; notesBtn.classList.remove('toggled');
       setupNumberPad();
       render(); startTimer(); updateUndoBtn();
     }
@@ -429,8 +499,21 @@
       }
       stopTimer(); msgEl.textContent='Bra jobbat! Sudoku löst!';
     }
-    function reset() { current = puzzle.map(r=>[...r]); moves = []; render(); msgEl.textContent='Brädet återställdes.'; updateUndoBtn();}
-    function solveIt() { current = fullSolution.map(r=>[...r]); render(); stopTimer(); msgEl.textContent='Lösningen visas!'; }
+    function reset() {
+      current = puzzle.map(r=>[...r]);
+      createEmptyNotes();
+      moves = [];
+      render();
+      msgEl.textContent='Brädet återställdes.';
+      updateUndoBtn();
+    }
+    function solveIt() {
+      current = fullSolution.map(r=>[...r]);
+      createEmptyNotes();
+      render();
+      stopTimer();
+      msgEl.textContent='Lösningen visas!';
+    }
     function toggleHelper() { helperVisible = !helperVisible; helperEl.classList.toggle('hidden', !helperVisible); }
     function showHint() {
       updateErrors(); msgEl.textContent='';
@@ -451,7 +534,10 @@
     }
     function revealHint(r,c,tech) {
       saveMove(r,c,current[r][c]);
-      current[r][c]=fullSolution[r][c]; render(); msgEl.textContent=`Ledtråd (${tech}): Placera ${fullSolution[r][c]} på rad ${r+1}, kolumn ${c+1}.`;
+      current[r][c]=fullSolution[r][c];
+      notes[r][c]=[];
+      render();
+      msgEl.textContent=`Ledtråd (${tech}): Placera ${fullSolution[r][c]} på rad ${r+1}, kolumn ${c+1}.`;
     }
     document.getElementById('themeToggle').onclick = () => document.body.classList.toggle('dark-mode');
     document.getElementById('newBtn').onclick=newGame;
@@ -459,6 +545,10 @@
     document.getElementById('resetBtn').onclick=reset;
     document.getElementById('solveBtn').onclick=solveIt;
     document.getElementById('helperBtn').onclick=toggleHelper;
+    notesBtn.onclick = () => {
+      notesMode = !notesMode;
+      notesBtn.classList.toggle('toggled', notesMode);
+    };
     document.getElementById('hintBtn').onclick=showHint;
     document.getElementById('difficulty').onchange=newGame;
     undoBtn.onclick = undo;


### PR DESCRIPTION
## Summary
- enable a notes mode so players can add small candidate numbers
- add a button to toggle notes mode
- store notes and render them inside cells
- reset notes when starting a new game or solving

## Testing
- `git log -1 --stat`