### PR TITLE
Add dark red feedback for wrong numbers

### DIFF
--- a/game.html
+++ b/game.html
@@ -210,7 +210,7 @@
       highlightNumberPad();
     }
     function updateErrors() {
-      document.querySelectorAll('.cell').forEach(cell=>cell.classList.remove('error','hint'));
+      document.querySelectorAll('.cell').forEach(cell=>cell.classList.remove('error','hint','wrong'));
       for (let r=0;r<9;r++) for (let c=0;c<9;c++) {
         const v=current[r][c]; if (!v||readonly[r][c]) continue;
         for (let i=0;i<9;i++) {
@@ -222,9 +222,13 @@
           const rr=sr+i, cc=sc+j;
           if ((rr!==r||cc!==c) && current[rr][cc]===v) markErr(rr,cc);
         }
+        if(v !== fullSolution[r][c]) markWrong(r,c);
       }
       function markErr(r,c){
         document.querySelector(`.cell[data-r="${r}"][data-c="${c}"]`)?.classList.add('error');
+      }
+      function markWrong(r,c){
+        document.querySelector(`.cell[data-r="${r}"][data-c="${c}"]`)?.classList.add('wrong');
       }
     }
     // --- Sifferpanel ---

--- a/guide.html
+++ b/guide.html
@@ -178,7 +178,7 @@
       highlightNumberPad();
     }
     function updateErrors() {
-      document.querySelectorAll('.cell').forEach(cell=>cell.classList.remove('error','hint'));
+      document.querySelectorAll('.cell').forEach(cell=>cell.classList.remove('error','hint','wrong'));
       for (let r=0;r<9;r++) for (let c=0;c<9;c++) {
         const v=current[r][c]; if (!v||readonly[r][c]) continue;
         for (let i=0;i<9;i++) {
@@ -189,9 +189,13 @@
           const rr=sr+i, cc=sc+j;
           if ((rr!==r||cc!==c) && current[rr][cc]===v) markErr(rr,cc);
         }
+        if(v !== fullSolution[r][c]) markWrong(r,c);
       }
       function markErr(r,c){
         document.querySelector(`.cell[data-r="${r}"][data-c="${c}"]`)?.classList.add('error');
+      }
+      function markWrong(r,c){
+        document.querySelector(`.cell[data-r="${r}"][data-c="${c}"]`)?.classList.add('wrong');
       }
     }
     // --- Sifferpanel ---

--- a/style.css
+++ b/style.css
@@ -12,6 +12,7 @@
 --accent-hover: #2563eb;
 --error-bg: #fecaca;
 --error-text: #b91c1c;
+--wrong-text: #8b0000;
 --hint-bg: #bbf7d0;
 --hint-text: #059669;
 --btn-shadow: 0 2px 8px rgba(34,41,47,0.10);
@@ -94,6 +95,7 @@ cursor: default;
 }
 .cell.selected { background: #dbeafe; }
 .cell.error { background: var(--error-bg); color: var(--error-text); }
+.cell.wrong { color: var(--wrong-text); }
 .cell.hint { background: var(--hint-bg); color: var(--hint-text); }
 .row-highlight { background: rgba(255,255,0,0.16); }
 .col-highlight { background: rgba(0,255,255,0.14); }


### PR DESCRIPTION
## Summary
- highlight wrong numbers in Sudoku by comparing user input with solution
- add `.cell.wrong` class styled with dark red text

## Testing
- `true`